### PR TITLE
Fixing hcloud_ssh_keys and add some improvements

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -40,7 +40,7 @@ locals {
         shell               = "/bin/bash"
         sudo                = "ALL=(ALL) NOPASSWD:ALL"
         groups              = ["adm", "sudo", "docker"]
-        ssh_authorized_keys = var.my_public_ssh_keys
+        ssh_authorized_keys = var.cluster_user_public_ssh_keys
       }
     ],
     package_update             = true

--- a/swarm.tf.example
+++ b/swarm.tf.example
@@ -40,7 +40,7 @@ module "swarm-hetzner" {
 
   cluster_name       = "okami"
   cluster_user       = "swarm"
-  my_public_ssh_keys = var.my_public_ssh_keys
+  cluster_user_public_ssh_keys = var.my_public_ssh_keys
 
   docker_config = {
     metrics-addr = "0.0.0.0:9323"

--- a/swarm.tf.example
+++ b/swarm.tf.example
@@ -31,7 +31,7 @@ module "swarm-hetzner" {
 
   server_image    = "ubuntu-24.04"
   server_timezone = "Europe/Paris"
-  server_locale   = "fr_FR.UTF-8"
+  server_locale   = "en_GB.UTF-8"
   server_packages = ["nfs-common"]
 
   ssh_port = 2222

--- a/swarm.tf.example
+++ b/swarm.tf.example
@@ -54,20 +54,20 @@ module "swarm-hetzner" {
   nodes = [
     {
       name        = "manager"
-      server_type = "ccx13"
+      server_type = "cx22"
       location    = "nbg1"
       count       = 1
       ports       = ["80", "443"]
     },
     {
       name        = "worker"
-      server_type = "ccx13"
+      server_type = "cx22"
       location    = "nbg1"
       count       = 2
     },
     {
       name        = "storage"
-      server_type = "ccx13"
+      server_type = "cx22"
       location    = "nbg1"
       count       = 1
     }

--- a/swarm.tf.example
+++ b/swarm.tf.example
@@ -36,8 +36,6 @@ module "swarm-hetzner" {
 
   ssh_port = 2222
 
-  hcloud_ssh_keys = ["home"]
-
   cluster_name       = "okami"
   cluster_user       = "swarm"
   cluster_user_public_ssh_keys = var.my_public_ssh_keys

--- a/vars.tf
+++ b/vars.tf
@@ -52,17 +52,17 @@ variable "cluster_user" {
   description = "The default non-root user (UID=1000) that will be used to access the servers"
 }
 
-variable "hcloud_ssh_keys" {
-  description = "List of hcloud SSH keys that will be used to access the servers"
-  default     = []
-  type        = list(string)
-}
-
-variable "my_public_ssh_keys" {
-  description = "Your public SSH keys that will be used to access the servers"
+variable "cluster_user_public_ssh_keys" {
+  description = "Your public SSH keys that will be used to access the cluster user on the servers"
   type        = list(string)
   sensitive   = true
   default     = []
+}
+
+variable "hcloud_ssh_keys" {
+  description = "List of names of hcloud SSH keys that already exist in the hetzner environment and will be used to access the server via the image default user like root"
+  default     = []
+  type        = list(string)
 }
 
 variable "my_ip_addresses" {


### PR DESCRIPTION
Hi Adrien,

thanks alot for this project and your [nice blog entries](https://blog.okami101.io/2022/02/setup-a-docker-swarm-cluster-for-less-than-30-/-month/) about this topic. I have some minor suggestions to make this more understandable and streamlined

- The "hcloud_ssh_keys" in the example triggers an error, when there is no "home" pubkey preconfigured in the hetzner environment
- Clarifying the difference between the pubkeys of the cluster user and the hcloud ssh keys
- Cheaper instances as default and an english locale

Thx again and have a great week