### PR TITLE
Server placement groups

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -32,6 +32,12 @@ locals {
       ports = s.ports != null ? s.ports : []
     }
   ]
+  placement_groups = [
+    for s in var.nodes : {
+      name  = s.name
+      type = s.physical_placement
+    } if s.physical_placement != null
+  ]
   cloud_init = {
     users = [
       {

--- a/locals.tf
+++ b/locals.tf
@@ -34,7 +34,7 @@ locals {
   ]
   placement_groups = [
     for s in var.nodes : {
-      name  = s.name
+      name = s.name
       type = s.physical_placement
     } if s.physical_placement != null
   ]

--- a/main.tf
+++ b/main.tf
@@ -72,3 +72,9 @@ resource "hcloud_load_balancer_target" "lb_targets" {
     hcloud_server_network.servers
   ]
 }
+
+resource "hcloud_placement_group" "swarm" {
+  for_each = { for pg in local.placement_groups : pg.name => pg }
+  name     = "${var.cluster_name}-${each.value.name}"
+  type = each.value.type
+}

--- a/main.tf
+++ b/main.tf
@@ -76,5 +76,5 @@ resource "hcloud_load_balancer_target" "lb_targets" {
 resource "hcloud_placement_group" "swarm" {
   for_each = { for pg in local.placement_groups : pg.name => pg }
   name     = "${var.cluster_name}-${each.value.name}"
-  type = each.value.type
+  type     = each.value.type
 }

--- a/servers.tf
+++ b/servers.tf
@@ -12,12 +12,15 @@ resource "hcloud_server" "servers" {
   ]
   ssh_keys = var.hcloud_ssh_keys
   depends_on = [
-    hcloud_network_subnet.node
+    hcloud_network_subnet.node,
+    hcloud_placement_group.swarm
   ]
   user_data = <<-EOT
 #cloud-config
 ${yamlencode(local.cloud_init)}
 EOT
+
+  placement_group_id = contains(keys(hcloud_placement_group.swarm), each.value.name) ? hcloud_placement_group.swarm[each.value.name].id : null
 
   lifecycle {
     ignore_changes = [

--- a/swarm.tf.example
+++ b/swarm.tf.example
@@ -58,6 +58,9 @@ module "swarm-hetzner" {
       location    = "nbg1"
       count       = 1
       ports       = ["80", "443"]
+      # Optionally add the nodes to a placement group which spread each node to a different physical server
+      # You can add them later as well, but the nodes need to be stopped in order to do that
+      #physical_placement = "spread"
     },
     {
       name        = "worker"

--- a/vars.tf
+++ b/vars.tf
@@ -90,6 +90,7 @@ variable "nodes" {
     count       = number
     ports       = optional(list(string))
     lb_type     = optional(string)
+    physical_placement = optional(string)
   }))
   default = []
 }

--- a/vars.tf
+++ b/vars.tf
@@ -84,12 +84,12 @@ variable "docker_config" {
 variable "nodes" {
   description = "List of all nodes types to create for swarm cluster. Each type can have a different number of instances."
   type = list(object({
-    name        = string
-    server_type = string
-    location    = string
-    count       = number
-    ports       = optional(list(string))
-    lb_type     = optional(string)
+    name               = string
+    server_type        = string
+    location           = string
+    count              = number
+    ports              = optional(list(string))
+    lb_type            = optional(string)
     physical_placement = optional(string)
   }))
   default = []


### PR DESCRIPTION
Hi!

Hetzner provides the functionality to spread cloud servers across physical servers via placement groups (https://docs.hetzner.com/cloud/placement-groups/faq).

With the pr you can activate this per node group via `physical_placement = "spread"` (currently the only option is "spread")

o/